### PR TITLE
Use Ubuntu 17.10 as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:17.10
 
 LABEL maintainer="ownCloud DevOps <devops@owncloud.com>" \
   org.label-schema.name="ownCloud Ubuntu" \


### PR DESCRIPTION
This PR sets Ubuntu 17.10 as the base image for the container. This is required because ownCloud 10.0.8 requires this as the minimum PHP version, yet PHP 7.1 isn't available with Ubuntu 16.04.