### PR TITLE
Install wget for 19.10 build step

### DIFF
--- a/v19.10/Dockerfile.amd64
+++ b/v19.10/Dockerfile.amd64
@@ -1,5 +1,7 @@
 FROM ubuntu:19.10 as build
 
+RUN apt-get update && apt-get install -y wget
+
 ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
 ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
 

--- a/v19.10/Dockerfile.arm32v7
+++ b/v19.10/Dockerfile.arm32v7
@@ -1,5 +1,7 @@
 FROM arm32v7/ubuntu:19.10 as build
 
+RUN apt-get update && apt-get install -y wget
+
 ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
 ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
 

--- a/v19.10/Dockerfile.arm64v8
+++ b/v19.10/Dockerfile.arm64v8
@@ -1,5 +1,7 @@
 FROM arm64v8/ubuntu:19.10 as build
 
+RUN apt-get update && apt-get install -y wget
+
 ENV WAIT_FOR_IT_DOWNLOAD=https://raw.githubusercontent.com/jdufner/wait-for-it/9730b3a4817084a2504a2f553b316cf211166acd/wait-for-it.sh
 ENV WAIT_FOR_IT_CHECKSUM=1352dacf4e3f97b023d5cebad1d56f317e31af1bfd06bc2fed83fe94f21c3455
 


### PR DESCRIPTION
All other docker images already install wget to download all required
files, it was just missing for 19.10.