### PR TITLE
fix drone builds

### DIFF
--- a/latest/manifest.tmpl
+++ b/latest/manifest.tmpl
@@ -1,12 +1,10 @@
 image: owncloud/ubuntu:latest
-tags:
-  - focal
 manifests:
-  - image: owncloud/ubuntu:latest-amd64
+  - image: owncloud/ubuntu:amd64
     platform:
       architecture: amd64
       os: linux
-  - image: owncloud/ubuntu:latest-arm64v8
+  - image: owncloud/ubuntu:arm64v8
     platform:
       architecture: arm64
       variant: v8


### PR DESCRIPTION
Aha, the manifest is used by drone only when really publishing, not when test driving...
Apparently 'latest' images should not have 'latest' in their name.