### PR TITLE
pin gomplate to different version for arm64

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -2,13 +2,13 @@ FROM amd64/ubuntu:20.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.7.0/gomplate_linux-amd64-slim
-ENV GOMPLATE_CHECKSUM=edeafbade658f4cf8dde853b7b2d8b8441936587bded5d32444efee3d3be9b87
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-amd64-slim
+ENV GOMPLATE_CHECKSUM=6a780f3c9fa55fa583833322b522e14a19f857f4a4058af1a65fac21b342447a
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
   echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
-  chmod +x gomplate
+  chmod +x gomplate && ./gomplate --version
 
 ENV SU_EXEC_DOWNLOAD=https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64
 ENV SU_EXEC_CHECKSUM=5b3b03713a888cee84ecbf4582b21ac9fd46c3d935ff2d7ea25dd5055d302d3c

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -2,13 +2,13 @@ FROM arm32v7/ubuntu:20.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.7.0/gomplate_linux-armv7-slim
-ENV GOMPLATE_CHECKSUM=fd3cccfbe624cada97843495551a5ea26628078daaa39128a090cab461bc76f5
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-armv7-slim
+ENV GOMPLATE_CHECKSUM=c3d4dbc59955b1107b48e0018a7931374f3dc0da9536ae89f9091fce87740af4
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
   echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
-  chmod +x gomplate
+  chmod +x gomplate && ./gomplate --version
 
 ENV SU_EXEC_DOWNLOAD=https://github.com/tianon/gosu/releases/download/1.11/gosu-armhf
 ENV SU_EXEC_CHECKSUM=171b4a2decc920de0dd4f49278d3e14712da5fa48de57c556f99bcdabe03552e

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -8,7 +8,7 @@ ENV GOMPLATE_CHECKSUM=82345969b05cd7041206e44341741737b1a8cfd5a20c1d6516bedcb076
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
   echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
-  chmod +x gomplate
+  chmod +x gomplate && ./gomplate --version
 
 ENV SU_EXEC_DOWNLOAD=https://github.com/tianon/gosu/releases/download/1.11/gosu-arm64
 ENV SU_EXEC_CHECKSUM=5e279972a1c7adee65e3b5661788e8706594b458b7ce318fecbd392492cc4dbd

--- a/v18.04/Dockerfile.amd64
+++ b/v18.04/Dockerfile.amd64
@@ -8,7 +8,7 @@ ENV GOMPLATE_CHECKSUM=6a780f3c9fa55fa583833322b522e14a19f857f4a4058af1a65fac21b3
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
   echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
-  chmod +x gomplate
+  chmod +x gomplate && ./gomplate --version
 
 ENV SU_EXEC_DOWNLOAD=https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64
 ENV SU_EXEC_CHECKSUM=5b3b03713a888cee84ecbf4582b21ac9fd46c3d935ff2d7ea25dd5055d302d3c

--- a/v18.04/Dockerfile.arm32v7
+++ b/v18.04/Dockerfile.arm32v7
@@ -8,7 +8,7 @@ ENV GOMPLATE_CHECKSUM=c3d4dbc59955b1107b48e0018a7931374f3dc0da9536ae89f9091fce87
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
   echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
-  chmod +x gomplate
+  chmod +x gomplate && ./gomplate --version
 
 ENV SU_EXEC_DOWNLOAD=https://github.com/tianon/gosu/releases/download/1.11/gosu-armhf
 ENV SU_EXEC_CHECKSUM=171b4a2decc920de0dd4f49278d3e14712da5fa48de57c556f99bcdabe03552e

--- a/v18.04/Dockerfile.arm64v8
+++ b/v18.04/Dockerfile.arm64v8
@@ -2,13 +2,13 @@ FROM arm64v8/ubuntu:18.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-arm64-slim
-ENV GOMPLATE_CHECKSUM=d96a92c531fb1639d0936be5b0ab492efe1a3903b6660db73728389875ee515b
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.7.0/gomplate_linux-arm64-slim
+ENV GOMPLATE_CHECKSUM=82345969b05cd7041206e44341741737b1a8cfd5a20c1d6516bedcb076f08ed7
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
   echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
-  chmod +x gomplate
+  chmod +x gomplate && ./gomplate --version
 
 ENV SU_EXEC_DOWNLOAD=https://github.com/tianon/gosu/releases/download/1.11/gosu-arm64
 ENV SU_EXEC_CHECKSUM=5e279972a1c7adee65e3b5661788e8706594b458b7ce318fecbd392492cc4dbd

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -8,7 +8,7 @@ ENV GOMPLATE_CHECKSUM=6a780f3c9fa55fa583833322b522e14a19f857f4a4058af1a65fac21b3
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
   echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
-  chmod +x gomplate
+  chmod +x gomplate && ./gomplate --version
 
 ENV SU_EXEC_DOWNLOAD=https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64
 ENV SU_EXEC_CHECKSUM=5b3b03713a888cee84ecbf4582b21ac9fd46c3d935ff2d7ea25dd5055d302d3c

--- a/v20.04/Dockerfile.arm32v7
+++ b/v20.04/Dockerfile.arm32v7
@@ -8,7 +8,7 @@ ENV GOMPLATE_CHECKSUM=c3d4dbc59955b1107b48e0018a7931374f3dc0da9536ae89f9091fce87
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
   echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
-  chmod +x gomplate
+  chmod +x gomplate && ./gomplate --version
 
 ENV SU_EXEC_DOWNLOAD=https://github.com/tianon/gosu/releases/download/1.11/gosu-armhf
 ENV SU_EXEC_CHECKSUM=171b4a2decc920de0dd4f49278d3e14712da5fa48de57c556f99bcdabe03552e

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -2,13 +2,13 @@ FROM arm64v8/ubuntu:20.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-arm64-slim
-ENV GOMPLATE_CHECKSUM=d96a92c531fb1639d0936be5b0ab492efe1a3903b6660db73728389875ee515b
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.7.0/gomplate_linux-arm64-slim
+ENV GOMPLATE_CHECKSUM=82345969b05cd7041206e44341741737b1a8cfd5a20c1d6516bedcb076f08ed7
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \
   echo "${GOMPLATE_CHECKSUM} *gomplate" | sha256sum -c - && \
-  chmod +x gomplate
+  chmod +x gomplate && ./gomplate --version
 
 ENV SU_EXEC_DOWNLOAD=https://github.com/tianon/gosu/releases/download/1.11/gosu-arm64
 ENV SU_EXEC_CHECKSUM=5e279972a1c7adee65e3b5661788e8706594b458b7ce318fecbd392492cc4dbd


### PR DESCRIPTION
- pin gomplate to 3.7.0 instead of 3.9.0 for arm64 because of segfault, see also https://github.com/hairyhenderson/gomplate/issues/1085
- update gomplate for non arm64 ubuntu latest image
- test gomplate upon install to notice future segfaults way earlier