### PR TITLE
switch to non slim gomplate

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -2,8 +2,8 @@ FROM amd64/ubuntu:20.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-amd64-slim
-ENV GOMPLATE_CHECKSUM=6a780f3c9fa55fa583833322b522e14a19f857f4a4058af1a65fac21b342447a
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-amd64
+ENV GOMPLATE_CHECKSUM=7dbabe30095f822ec38f5f70711ff121c26e588227da4cc05208417cfaf929cd
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -2,8 +2,8 @@ FROM arm32v7/ubuntu:20.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-armv7-slim
-ENV GOMPLATE_CHECKSUM=c3d4dbc59955b1107b48e0018a7931374f3dc0da9536ae89f9091fce87740af4
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-armv7
+ENV GOMPLATE_CHECKSUM=8fae2244bf96d8db1f48acc50a8b1d86a1bf69f1ba27e326933840759deb2b34
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -2,8 +2,8 @@ FROM arm64v8/ubuntu:20.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.7.0/gomplate_linux-arm64-slim
-ENV GOMPLATE_CHECKSUM=82345969b05cd7041206e44341741737b1a8cfd5a20c1d6516bedcb076f08ed7
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-arm64
+ENV GOMPLATE_CHECKSUM=3fc4f88bfd68103d0489932d7fa65bd8590bca6bb6bf1c0e82c3b9f27deee267
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \

--- a/v18.04/Dockerfile.amd64
+++ b/v18.04/Dockerfile.amd64
@@ -2,8 +2,8 @@ FROM amd64/ubuntu:18.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-amd64-slim
-ENV GOMPLATE_CHECKSUM=6a780f3c9fa55fa583833322b522e14a19f857f4a4058af1a65fac21b342447a
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-amd64
+ENV GOMPLATE_CHECKSUM=7dbabe30095f822ec38f5f70711ff121c26e588227da4cc05208417cfaf929cd
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \

--- a/v18.04/Dockerfile.arm32v7
+++ b/v18.04/Dockerfile.arm32v7
@@ -2,8 +2,8 @@ FROM arm32v7/ubuntu:18.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-armv7-slim
-ENV GOMPLATE_CHECKSUM=c3d4dbc59955b1107b48e0018a7931374f3dc0da9536ae89f9091fce87740af4
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-armv7
+ENV GOMPLATE_CHECKSUM=8fae2244bf96d8db1f48acc50a8b1d86a1bf69f1ba27e326933840759deb2b34
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \

--- a/v18.04/Dockerfile.arm64v8
+++ b/v18.04/Dockerfile.arm64v8
@@ -2,8 +2,8 @@ FROM arm64v8/ubuntu:18.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.7.0/gomplate_linux-arm64-slim
-ENV GOMPLATE_CHECKSUM=82345969b05cd7041206e44341741737b1a8cfd5a20c1d6516bedcb076f08ed7
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-arm64
+ENV GOMPLATE_CHECKSUM=3fc4f88bfd68103d0489932d7fa65bd8590bca6bb6bf1c0e82c3b9f27deee267
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \

--- a/v20.04/Dockerfile.arm32v7
+++ b/v20.04/Dockerfile.arm32v7
@@ -2,8 +2,8 @@ FROM arm32v7/ubuntu:20.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-armv7-slim
-ENV GOMPLATE_CHECKSUM=c3d4dbc59955b1107b48e0018a7931374f3dc0da9536ae89f9091fce87740af4
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-armv7
+ENV GOMPLATE_CHECKSUM=8fae2244bf96d8db1f48acc50a8b1d86a1bf69f1ba27e326933840759deb2b34
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -2,8 +2,8 @@ FROM arm64v8/ubuntu:20.04 as build
 
 RUN apt-get update && apt-get install -y wget
 
-ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.7.0/gomplate_linux-arm64-slim
-ENV GOMPLATE_CHECKSUM=82345969b05cd7041206e44341741737b1a8cfd5a20c1d6516bedcb076f08ed7
+ENV GOMPLATE_DOWNLOAD=https://github.com/hairyhenderson/gomplate/releases/download/v3.9.0/gomplate_linux-arm64
+ENV GOMPLATE_CHECKSUM=3fc4f88bfd68103d0489932d7fa65bd8590bca6bb6bf1c0e82c3b9f27deee267
 
 RUN cd /tmp && \
   wget -O gomplate ${GOMPLATE_DOWNLOAD} && \


### PR DESCRIPTION
This PR switches from the slim to the normal variant of gomplate. This is a followup on the quickfix done in https://github.com/owncloud-docker/ubuntu/pull/49.

The compressed / slim Gomplate variant caused some trouble for us (and the gomplate maintainer too):
- https://github.com/hairyhenderson/gomplate/issues/821
- https://github.com/hairyhenderson/gomplate/issues/1085

Probably gomplate will also stop releasing the compressed / slim variant of it:
> I think I'll stop releasing UPX-compressed builds around the next release or so. I had originally intended the slim build as a way to save on bandwidth, but the execution time increases considerably so the tradeoff isn't a good one (especially since caching can help reduce bandwidth use).

Expected Implications:
- Image Size will be bigger
