### PR TITLE
Adding rsync as a new dependency in 10.9

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
     vim \
     curl \
     wget \
+    rsync \
     procps \
     apt-utils \
     apt-transport-https \

--- a/latest/Dockerfile.arm32v7
+++ b/latest/Dockerfile.arm32v7
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
     vim \
     curl \
     wget \
+    rsync \
     procps \
     apt-utils \
     apt-transport-https \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
     vim \
     curl \
     wget \
+    rsync \
     procps \
     apt-utils \
     apt-transport-https \

--- a/v18.04/Dockerfile.amd64
+++ b/v18.04/Dockerfile.amd64
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
     vim \
     curl \
     wget \
+    rsync \
     procps \
     apt-utils \
     apt-transport-https \

--- a/v18.04/Dockerfile.arm32v7
+++ b/v18.04/Dockerfile.arm32v7
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
     vim \
     curl \
     wget \
+    rsync \
     procps \
     apt-utils \
     apt-transport-https \

--- a/v18.04/Dockerfile.arm64v8
+++ b/v18.04/Dockerfile.arm64v8
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
     vim \
     curl \
     wget \
+    rsync \
     procps \
     apt-utils \
     apt-transport-https \

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
     vim \
     curl \
     wget \
+    rsync \
     procps \
     apt-utils \
     apt-transport-https \

--- a/v20.04/Dockerfile.arm32v7
+++ b/v20.04/Dockerfile.arm32v7
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
     vim \
     curl \
     wget \
+    rsync \
     procps \
     apt-utils \
     apt-transport-https \

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -31,6 +31,7 @@ RUN apt-get update -y && \
     vim \
     curl \
     wget \
+    rsync \
     procps \
     apt-utils \
     apt-transport-https \


### PR DESCRIPTION
Needed for new command `occ user:move`
As discussed in https://github.com/owncloud/core/issues/39560#issuecomment-987873797