### PR TITLE
chore: avoid installing recommended packages

### DIFF
--- a/latest/Dockerfile.amd64
+++ b/latest/Dockerfile.amd64
@@ -18,7 +18,7 @@ ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.0.1}"
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 
 RUN apt-get update -y && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     ca-certificates \
     bash \
     curl \

--- a/latest/Dockerfile.arm64v8
+++ b/latest/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.0.1}"
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 
 RUN apt-get update -y && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     ca-certificates \
     bash \
     curl \

--- a/v18.04/Dockerfile.amd64
+++ b/v18.04/Dockerfile.amd64
@@ -18,7 +18,7 @@ ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.0.1}"
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 
 RUN apt-get update -y && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     ca-certificates \
     bash \
     curl \

--- a/v18.04/Dockerfile.arm64v8
+++ b/v18.04/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.0.1}"
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 
 RUN apt-get update -y && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     ca-certificates \
     bash \
     curl \

--- a/v20.04/Dockerfile.amd64
+++ b/v20.04/Dockerfile.amd64
@@ -18,7 +18,7 @@ ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.0.1}"
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 
 RUN apt-get update -y && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     ca-certificates \
     bash \
     curl \

--- a/v20.04/Dockerfile.arm64v8
+++ b/v20.04/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.0.1}"
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 
 RUN apt-get update -y && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     ca-certificates \
     bash \
     curl \

--- a/v22.04/Dockerfile.amd64
+++ b/v22.04/Dockerfile.amd64
@@ -18,7 +18,7 @@ ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.0.1}"
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 
 RUN apt-get update -y && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     ca-certificates \
     bash \
     curl \

--- a/v22.04/Dockerfile.arm64v8
+++ b/v22.04/Dockerfile.arm64v8
@@ -18,7 +18,7 @@ ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.0.1}"
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 
 RUN apt-get update -y && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     ca-certificates \
     bash \
     curl \


### PR DESCRIPTION
```
diff -c ~/.tmp/ubuntu-old.txt ~/.tmp/ubuntu-new.txt 
*** ubuntu-old.txt	2023-06-02 10:37:41.072312502 +0200
--- ubuntu-new.txt	2023-06-02 11:09:52.345422359 +0200
***************
*** 36,42 ****
  hostname
  init-system-helpers
  jq
- krb5-locales
  libacl1
  libapt-pkg6.0
  libasn1-8-heimdal
--- 36,41 ----
***************
*** 104,110 ****
  librtmp1
  libsasl2-2
  libsasl2-modules-db
- libsasl2-modules
  libseccomp2
  libselinux1
  libsemanage-common
--- 103,108 ----
***************
*** 136,142 ****
  perl-base
  pinentry-curses
  procps
- publicsuffix
  readline-common
  sed
  sensible-utils
--- 134,139 ----
```