### PR TITLE
chore: add Ubuntu 24.04 Noble Numbat

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -4,6 +4,10 @@ DRONE_DOCKER_BUILDX_IMAGE = "docker.io/owncloudci/drone-docker-buildx:4"
 def main(ctx):
     versions = [
         {
+            "value": "24.04",
+            "tags": ["noble"],
+        },
+        {
             "value": "22.04",
             "tags": ["jammy"],
         },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2025-04-15
+
+* Added
+  * Add Ubuntu 24.04
+
 ## 2022-06-07
 
 * Added

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ownCloud Docker Ubuntu base image based on the [official Ubuntu](https://registr
 
 ## Docker Tags and respective Dockerfile links
 
+- [`24.04`](https://github.com/owncloud-docker/ubuntu/blob/master/v24.04/Dockerfile.multiarch) available as `owncloud/ubuntu:24.04`
 - [`22.04`](https://github.com/owncloud-docker/ubuntu/blob/master/v22.04/Dockerfile.multiarch) available as `owncloud/ubuntu:22.04`
 - [`20.04`](https://github.com/owncloud-docker/ubuntu/blob/master/v20.04/Dockerfile.multiarch) available as `owncloud/ubuntu:20.04`,`owncloud/ubuntu:latest`
 

--- a/v24.04/Dockerfile.multiarch
+++ b/v24.04/Dockerfile.multiarch
@@ -1,0 +1,49 @@
+FROM docker.io/ubuntu:24.04
+
+LABEL maintainer="ownCloud GmbH <devops@owncloud.com>" \
+  org.opencontainers.image.authors="ownCloud DevOps <devops@owncloud.com>" \
+  org.opencontainers.image.title="ownCloud Ubuntu" \
+  org.opencontainers.image.url="https://hub.docker.com/r/owncloud/ubuntu" \
+  org.opencontainers.image.source="https://github.com/owncloud-docker/ubuntu" \
+  org.opencontainers.image.documentation="https://github.com/owncloud-docker/ubuntu"
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM xterm
+
+# renovate: datasource=github-releases depName=hairyhenderson/gomplate
+ENV GOMPLATE_VERSION="${GOMPLATE_VERSION:-v4.3.2}"
+# renovate: datasource=github-releases depName=owncloud-ci/wait-for
+ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.0.5}"
+# renovate: datasource=github-releases depName=owncloud-ci/retry
+ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
+
+RUN apt-get update -y && \
+  apt-get install --no-install-recommends -y \
+    ca-certificates \
+    bash \
+    curl \
+    wget \
+    procps \
+    apt-utils \
+    apt-transport-https \
+    bzip2 \
+    cron \
+    jq \
+    gnupg \
+    libnss-wrapper && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN curl -SsfL -o /usr/bin/gomplate "https://github.com/hairyhenderson/gomplate/releases/download/${GOMPLATE_VERSION}/gomplate_${TARGETOS}-${TARGETARCH}${TARGETVARIANT}" && \
+    curl -SsfL -o /usr/bin/wait-for "https://github.com/owncloud-ci/wait-for/releases/download/${WAIT_FOR_VERSION}/wait-for-${TARGETOS}-${TARGETARCH}${TARGETVARIANT}" && \
+    curl -SsfL -o /usr/bin/retry "https://github.com/owncloud-ci/retry/releases/download/${RETRY_VERSION}/retry" && \
+    chmod 755 /usr/bin/gomplate && \
+    chmod 755 /usr/bin/wait-for && \
+    chmod 755 /usr/bin/retry
+
+ADD overlay /
+CMD ["bash"]

--- a/v24.04/overlay/usr/bin/wait-for-it
+++ b/v24.04/overlay/usr/bin/wait-for-it
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+while getopts "t:" o; do
+    case ${o} in
+    t)
+        TIMEOUT=${OPTARG}
+        ;;
+    *) ;;
+
+    esac
+done
+
+shift $((OPTIND - 1))
+exec wait-for -t "${TIMEOUT:-20}" -it "${@}"


### PR DESCRIPTION
We want to provide different PHP 7.4 etc, which will happen in coming PRs to https://github.com/owncloud-docker/php
But we also want to be able to base it on newer Ubuntu long-term releases.
This repo currently has 20.04 and 22.04 LTS releases. This PR adds the 24.04 LTS release that was published in 2024.

Note: this will also let us publish an https://github.com/owncloud-ci/php for use in CI that is based on Ubuntu 24.04, so that we can use that for testing in CI to verify that various unit, API and webUI tests all pass when using Ubuntu 24.04 as the base operating system.