### PR TITLE
feat: add Orca Security container image scanning

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,11 +30,16 @@ on:
         required: false
         type: string
         default: ""
+      orca-security-project-key:
+        required: true
+        type: string
     secrets:
       docker-hub-password:
         required: true
       docker-secrets:
         required: false
+      orca-security-api-token:
+        required: true
 
 jobs:
   build:
@@ -76,6 +81,14 @@ jobs:
           skip-files: /usr/bin/gomplate,/usr/bin/wait-for
           exit-code: 1
           trivyignores: ${{ inputs.trivy-ignore-files }}
+
+      - name: Orca Security scan
+        uses: orcasecurity/shiftleft-container-image-action@9cceca839ca144e6bb160a1d974d0656bcf71f22 # v1.0.6
+        with:
+          api_token: ${{ secrets.orca-security-api-token }}
+          project_key: ${{ inputs.orca-security-project-key }}
+          image: registry:5000/image:temp
+          exit_code: "1"
 
       - name: Set publish tags
         if: ${{ inputs.push }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,10 @@ jobs:
       docker-file: v${{ matrix.version.value }}/Dockerfile.multiarch
       docker-hub-username: ${{ vars.DOCKERHUB_USERNAME }}
       push: ${{ github.ref == 'refs/heads/master' }}
+      orca-security-project-key: ${{ vars.ORCA_SECURITY_PROJECT_KEY }}
     secrets:
       docker-hub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+      orca-security-api-token: ${{ secrets.ORCA_SECURITY_API_TOKEN }}
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

- Add [Orca Security Container Image Scanning](https://github.com/marketplace/actions/orca-security-container-image-scanning) step to the Docker build workflow alongside the existing Trivy scan
- Pinned to `orcasecurity/shiftleft-container-image-action@9cceca839ca144e6bb160a1d974d0656bcf71f22` (v1.0.6)
- Both Trivy and Orca scans run on the locally-built image (`127.0.0.1:5000/image:temp`) before publishing
- Requires two new repository secrets/variables to be configured:
  - `ORCA_SECURITY_API_TOKEN` (secret) — Orca API token for authentication
  - `ORCA_SECURITY_PROJECT_KEY` (variable) — Orca project key

## Test plan

- [ ] Configure `ORCA_SECURITY_API_TOKEN` secret and `ORCA_SECURITY_PROJECT_KEY` variable in the repository settings
- [ ] Verify the Orca Security scan step runs after the Trivy scan step
- [ ] Verify the workflow fails (`exit_code: 1`) when Orca detects HIGH/CRITICAL vulnerabilities
- [ ] Verify the existing Trivy scan step is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)