### PR TITLE
feat: add optional trivy-ignore-files input to docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,6 +22,10 @@ on:
       push:
         required: true
         type: boolean
+      trivy-ignore-files:
+        required: false
+        type: string
+        default: ".trivyignore"
     secrets:
       docker-hub-password:
         required: true
@@ -67,8 +71,7 @@ jobs:
           ignore-unfixed: true
           skip-files: /usr/bin/gomplate,/usr/bin/wait-for
           exit-code: 1
-        env:
-          TRIVY_IGNOREFILE: .trivyignore
+          trivyignores: ${{ inputs.trivy-ignore-files }}
 
       # Push the image on merge to master
       - name: Login to Docker Hub


### PR DESCRIPTION
## Summary

- Adds optional `trivy-ignore-files` input to the `docker-build.yml` reusable workflow (default: `.trivyignore` — backwards compatible)
- Replaces the hardcoded `TRIVY_IGNOREFILE: .trivyignore` env var with the `trivyignores` input on the trivy-action step, which supports comma-separated paths
- Allows callers to pass per-version ignore files (e.g. `.trivyignore,v7/.trivyignore`) enabling version-specific CVE suppression for packaging repos

## Motivation

The `owncloud-docker/ocis` repo packages pre-built binaries per major version (v7, v8). Each version's binary may contain different sets of upstream CVEs that cannot be fixed by the packaging repo. Version-specific `.trivyignore` files allow these to be tracked and suppressed per-version with expiry dates.

## Backwards Compatibility

The default value is `.trivyignore`, so all existing callers that do not pass `trivy-ignore-files` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)