### PR TITLE
feat: add optional docker-extra-tags input for floating tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,6 +26,10 @@ on:
         required: false
         type: string
         default: ".trivyignore"
+      docker-extra-tags:
+        required: false
+        type: string
+        default: ""
     secrets:
       docker-hub-password:
         required: true
@@ -73,6 +77,24 @@ jobs:
           exit-code: 1
           trivyignores: ${{ inputs.trivy-ignore-files }}
 
+      - name: Set publish tags
+        if: ${{ inputs.push }}
+        id: tags
+        env:
+          DOCKER_REPO_NAME: ${{ inputs.docker-repo-name }}
+          DOCKER_TAG: ${{ inputs.docker-tag }}
+          DOCKER_EXTRA_TAGS: ${{ inputs.docker-extra-tags }}
+        run: |
+          TAGS="${DOCKER_REPO_NAME}:${DOCKER_TAG}"
+          if [ -n "${DOCKER_EXTRA_TAGS}" ]; then
+            while IFS= read -r tag; do
+              [ -n "$tag" ] && TAGS="${TAGS}"$'\n'"${DOCKER_REPO_NAME}:${tag}"
+            done <<< "${DOCKER_EXTRA_TAGS}"
+          fi
+          echo "list<<EOF" >> $GITHUB_OUTPUT
+          echo "$TAGS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       # Push the image on merge to master
       - name: Login to Docker Hub
         if: ${{ inputs.push }}
@@ -89,6 +111,6 @@ jobs:
           file: ${{ inputs.docker-file }}
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ inputs.docker-repo-name }}:${{ inputs.docker-tag }}
+          tags: ${{ steps.tags.outputs.list }}
           secrets: ${{ secrets.docker-secrets }}
           build-args: ${{ inputs.docker-build-args }}


### PR DESCRIPTION
## Summary

- Adds optional `docker-extra-tags` input (default: `""`) to `docker-build.yml`
- When non-empty, a `Set publish tags` step builds a newline-separated tag list combining the primary tag with each extra tag (prefixed with `docker-repo-name`)
- Extra tags are only applied to the final published image, not the Trivy scan temp image
- Backwards compatible: callers that do not pass `docker-extra-tags` behave exactly as before
- Input values used in `run:` steps are bound to `env:` variables and referenced as shell env vars — not interpolated directly — to prevent expression injection

## Example

Caller passes:
```yaml
with:
  docker-repo-name: owncloud/ocis
  docker-tag: "7.3.2"
  docker-extra-tags: |
    7.3
    7
```

Published tags: `owncloud/ocis:7.3.2`, `owncloud/ocis:7.3`, `owncloud/ocis:7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)