### PR TITLE
fix: add workflow_call trigger to lint-pr-title workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+  workflow_call:
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

- Adds `workflow_call:` trigger to `lint-pr-title.yml` so it can be used as a reusable workflow by callers
- Without this, callers using `uses: owncloud-docker/ubuntu/.github/workflows/lint-pr-title.yml@master` fail at workflow startup

## Unblocks

- owncloud-docker/ocis#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)