### PR TITLE
feat: add optional smoke test step to docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,18 +39,22 @@ on:
         required: false
         type: string
         default: ""
+        description: "URL to poll for HTTP 200 after starting the container. When empty, the smoke test step is skipped."
       smoke-test-env:
         required: false
         type: string
         default: ""
+        description: "Newline-separated list of KEY=VALUE pairs passed as --env to docker run."
       smoke-test-entrypoint-cmd:
         required: false
         type: string
         default: ""
+        description: "Override entrypoint to /bin/sh -c '<cmd>'. Must end with a long-running process (e.g. via exec) so the container stays alive for polling."
       smoke-test-version-jq:
         required: false
         type: string
         default: ""
+        description: "jq expression applied to the JSON response from smoke-test-url; result must equal docker-tag."
       smoke-test-cmd:
         required: false
         type: string
@@ -133,13 +137,15 @@ jobs:
           echo "Container started: ${CID}"
           echo "Polling ${SMOKE_URL} ..."
           STATUS=""
-          for i in $(seq 1 30); do
+          ELAPSED=0
+          for i in $(seq 1 31); do
             STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "${SMOKE_URL}")
             if [ "${STATUS}" = "200" ]; then
-              echo "Got HTTP 200 after $((i * 2 - 2))s"
+              echo "Got HTTP 200 after ${ELAPSED}s"
               break
             fi
             sleep 2
+            ELAPSED=$((ELAPSED + 2))
           done
           if [ "${STATUS}" != "200" ]; then
             echo "Timed out after 60s waiting for HTTP 200 (last status: ${STATUS})"
@@ -155,6 +161,7 @@ jobs:
             echo "Version verified: ${ACTUAL}"
           fi
 
+      # smoke-test-cmd and smoke-test-url are independent guards — both steps run if both inputs are set.
       - name: Smoke test (cmd)
         if: ${{ inputs.smoke-test-cmd != '' }}
         env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: string
         default: ""
+      smoke-test-cmd:
+        required: false
+        type: string
+        default: ""
+        description: "Shell command to run inside the container as a one-shot smoke test (for non-server images). Skipped when empty."
     secrets:
       docker-hub-password:
         required: true
@@ -149,6 +154,13 @@ jobs:
             fi
             echo "Version verified: ${ACTUAL}"
           fi
+
+      - name: Smoke test (cmd)
+        if: ${{ inputs.smoke-test-cmd != '' }}
+        env:
+          SMOKE_CMD: ${{ inputs.smoke-test-cmd }}
+        run: |
+          docker run --rm 127.0.0.1:5000/image:temp /bin/sh -c "${SMOKE_CMD}"
 
       - name: Set publish tags
         if: ${{ inputs.push }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -34,6 +34,7 @@ on:
         required: false
         type: string
         default: ""
+        description: "Port number to expose (host and container port will be identical, e.g. '9200')"
       smoke-test-url:
         required: false
         type: string
@@ -97,6 +98,9 @@ jobs:
           exit-code: 1
           trivyignores: ${{ inputs.trivy-ignore-files }}
 
+      # smoke-test-entrypoint-cmd is an entrypoint override: the command must end with
+      # a long-running process (e.g. via exec) so the container stays alive for polling.
+      # Example for oCIS: "ocis init || true; exec ocis server"
       - name: Smoke test
         if: ${{ inputs.smoke-test-url != '' }}
         env:
@@ -107,34 +111,36 @@ jobs:
           SMOKE_VERSION_JQ: ${{ inputs.smoke-test-version-jq }}
           DOCKER_TAG: ${{ inputs.docker-tag }}
         run: |
-          ARGS="--rm -d"
-          [ -n "${SMOKE_PORT}" ] && ARGS="${ARGS} -p ${SMOKE_PORT}:${SMOKE_PORT}"
+          ARGS=(--rm -d)
+          [ -n "${SMOKE_PORT}" ] && ARGS+=(-p "${SMOKE_PORT}:${SMOKE_PORT}")
           if [ -n "${SMOKE_ENV}" ]; then
             while IFS= read -r line; do
-              [ -n "$line" ] && ARGS="${ARGS} --env ${line}"
+              [ -n "$line" ] && ARGS+=(--env "${line}")
             done <<< "${SMOKE_ENV}"
           fi
           if [ -n "${SMOKE_ENTRYPOINT_CMD}" ]; then
-            CID=$(docker run ${ARGS} --entrypoint /bin/sh 127.0.0.1:5000/image:temp -c "${SMOKE_ENTRYPOINT_CMD}")
+            CID=$(docker run "${ARGS[@]}" --entrypoint /bin/sh 127.0.0.1:5000/image:temp -c "${SMOKE_ENTRYPOINT_CMD}")
           else
-            CID=$(docker run ${ARGS} 127.0.0.1:5000/image:temp)
+            CID=$(docker run "${ARGS[@]}" 127.0.0.1:5000/image:temp)
           fi
+          [ -z "${CID}" ] && { echo "docker run failed to start"; exit 1; }
           trap "docker stop ${CID} > /dev/null" EXIT
           echo "Container started: ${CID}"
           echo "Polling ${SMOKE_URL} ..."
+          STATUS=""
           for i in $(seq 1 30); do
             STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "${SMOKE_URL}")
             if [ "${STATUS}" = "200" ]; then
-              echo "Got HTTP 200 after $((i * 2))s"
+              echo "Got HTTP 200 after $((i * 2 - 2))s"
               break
-            fi
-            if [ "${i}" = "30" ]; then
-              echo "Timed out after 60s waiting for HTTP 200 (last status: ${STATUS})"
-              docker logs "${CID}"
-              exit 1
             fi
             sleep 2
           done
+          if [ "${STATUS}" != "200" ]; then
+            echo "Timed out after 60s waiting for HTTP 200 (last status: ${STATUS})"
+            docker logs "${CID}"
+            exit 1
+          fi
           if [ -n "${SMOKE_VERSION_JQ}" ]; then
             ACTUAL=$(curl -sk "${SMOKE_URL}" | jq -r "${SMOKE_VERSION_JQ}")
             if [ "${ACTUAL}" != "${DOCKER_TAG}" ]; then

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,6 +30,26 @@ on:
         required: false
         type: string
         default: ""
+      smoke-test-port:
+        required: false
+        type: string
+        default: ""
+      smoke-test-url:
+        required: false
+        type: string
+        default: ""
+      smoke-test-env:
+        required: false
+        type: string
+        default: ""
+      smoke-test-entrypoint-cmd:
+        required: false
+        type: string
+        default: ""
+      smoke-test-version-jq:
+        required: false
+        type: string
+        default: ""
     secrets:
       docker-hub-password:
         required: true
@@ -76,6 +96,53 @@ jobs:
           skip-files: /usr/bin/gomplate,/usr/bin/wait-for
           exit-code: 1
           trivyignores: ${{ inputs.trivy-ignore-files }}
+
+      - name: Smoke test
+        if: ${{ inputs.smoke-test-url != '' }}
+        env:
+          SMOKE_PORT: ${{ inputs.smoke-test-port }}
+          SMOKE_URL: ${{ inputs.smoke-test-url }}
+          SMOKE_ENV: ${{ inputs.smoke-test-env }}
+          SMOKE_ENTRYPOINT_CMD: ${{ inputs.smoke-test-entrypoint-cmd }}
+          SMOKE_VERSION_JQ: ${{ inputs.smoke-test-version-jq }}
+          DOCKER_TAG: ${{ inputs.docker-tag }}
+        run: |
+          ARGS="--rm -d"
+          [ -n "${SMOKE_PORT}" ] && ARGS="${ARGS} -p ${SMOKE_PORT}:${SMOKE_PORT}"
+          if [ -n "${SMOKE_ENV}" ]; then
+            while IFS= read -r line; do
+              [ -n "$line" ] && ARGS="${ARGS} --env ${line}"
+            done <<< "${SMOKE_ENV}"
+          fi
+          if [ -n "${SMOKE_ENTRYPOINT_CMD}" ]; then
+            CID=$(docker run ${ARGS} --entrypoint /bin/sh 127.0.0.1:5000/image:temp -c "${SMOKE_ENTRYPOINT_CMD}")
+          else
+            CID=$(docker run ${ARGS} 127.0.0.1:5000/image:temp)
+          fi
+          trap "docker stop ${CID} > /dev/null" EXIT
+          echo "Container started: ${CID}"
+          echo "Polling ${SMOKE_URL} ..."
+          for i in $(seq 1 30); do
+            STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "${SMOKE_URL}")
+            if [ "${STATUS}" = "200" ]; then
+              echo "Got HTTP 200 after $((i * 2))s"
+              break
+            fi
+            if [ "${i}" = "30" ]; then
+              echo "Timed out after 60s waiting for HTTP 200 (last status: ${STATUS})"
+              docker logs "${CID}"
+              exit 1
+            fi
+            sleep 2
+          done
+          if [ -n "${SMOKE_VERSION_JQ}" ]; then
+            ACTUAL=$(curl -sk "${SMOKE_URL}" | jq -r "${SMOKE_VERSION_JQ}")
+            if [ "${ACTUAL}" != "${DOCKER_TAG}" ]; then
+              echo "Version mismatch: expected '${DOCKER_TAG}', got '${ACTUAL}'"
+              exit 1
+            fi
+            echo "Version verified: ${ACTUAL}"
+          fi
 
       - name: Set publish tags
         if: ${{ inputs.push }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       docker-context: v${{ matrix.version.value }}
       docker-file: v${{ matrix.version.value }}/Dockerfile.multiarch
       docker-hub-username: ${{ vars.DOCKERHUB_USERNAME }}
+      smoke-test-cmd: ${{ matrix.version.smoke-test-cmd }}
       push: ${{ github.ref == 'refs/heads/master' }}
     secrets:
       docker-hub-password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -29,7 +30,9 @@ jobs:
       matrix:
         version:
           - value: "24.04"
+            smoke-test-cmd: ". /etc/os-release && [ \"${VERSION_ID}\" = \"24.04\" ]"
           - value: "22.04"
+            smoke-test-cmd: ". /etc/os-release && [ \"${VERSION_ID}\" = \"22.04\" ]"
 
   update-docker-hub-description:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
     uses: ./.github/workflows/lint-editorconfig.yml
 
   build:
+    name: build (${{ matrix.version.value }})
     needs: lint
     uses: ./.github/workflows/docker-build.yml
     with:


### PR DESCRIPTION
## Summary

- Adds 5 optional inputs to `docker-build.yml`: `smoke-test-port`, `smoke-test-url`, `smoke-test-env`, `smoke-test-entrypoint-cmd`, `smoke-test-version-jq`
- When `smoke-test-url` is empty (default), the `Smoke test` step is skipped — no change for existing callers
- When set, the step starts `127.0.0.1:5000/image:temp` from the local registry, polls the URL every 2s for up to 60s, and fails with container logs on timeout
- `smoke-test-entrypoint-cmd` overrides the entrypoint to `/bin/sh -c "<cmd>"` for images that need an init step (e.g. oCIS: `ocis init || true; exec ocis server`)
- `smoke-test-version-jq` optionally asserts a jq-extracted field from the response JSON equals `docker-tag`
- All inputs are bound to `env:` vars in the `run:` block — no inline expression interpolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)