### PR TITLE
fix: handle curl network errors in smoke test polling loop

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -139,7 +139,7 @@ jobs:
           STATUS=""
           ELAPSED=0
           for i in $(seq 1 31); do
-            STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "${SMOKE_URL}")
+            STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "${SMOKE_URL}") || STATUS="000"
             if [ "${STATUS}" = "200" ]; then
               echo "Got HTTP 200 after ${ELAPSED}s"
               break


### PR DESCRIPTION
## Root cause

The smoke test step runs under `bash -e -o pipefail`. When Docker starts a container with `-p 8080:8080 -d`, the userland proxy binds the host port immediately and **accepts** TCP connections — before Apache inside the container is ready. While ownCloud's first-run SQLite installation is running, the proxy accepts the connection then immediately resets it. curl exits with **code 56** (`CURLE_RECV_ERROR` — "failure in receiving network data"), which is non-zero and causes bash to abort the entire step with `set -e`.

The EXIT trap then runs `docker stop` with its default 10 s grace period, producing the characteristic ~10 s gap between `Polling …` and the `##[error]Process completed with exit code 56.` seen in CI.

## Fix

Add `|| STATUS="000"` so curl network errors (exit codes 7, 56, etc.) are caught and treated as "not ready yet", allowing the loop to continue polling for the full 60 s.

## Test plan

- [ ] Re-run smoke test CI against owncloud-docker/server PR #600 — all matrix builds should poll through the init phase and get HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)