### PR TITLE
fix: use --entrypoint /bin/sh in smoke-test-cmd to support binary entrypoints

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -179,7 +179,7 @@ jobs:
         env:
           SMOKE_CMD: ${{ inputs.smoke-test-cmd }}
         run: |
-          docker run --rm 127.0.0.1:5000/image:temp /bin/sh -c "${SMOKE_CMD}"
+          docker run --rm --entrypoint /bin/sh 127.0.0.1:5000/image:temp -c "${SMOKE_CMD}"
 
       - name: Set publish tags
         if: ${{ inputs.push }}


### PR DESCRIPTION
## Problem

The `smoke-test-cmd` step runs:

```bash
docker run --rm image /bin/sh -c "${SMOKE_CMD}"
```

This works for images with no `ENTRYPOINT` or with a shell wrapper entrypoint (e.g. `/usr/bin/entrypoint` that calls `exec "$@"`). However, for images with a binary `ENTRYPOINT` (e.g. `ENTRYPOINT ["wait-for"]`), Docker passes `/bin/sh -c "..."` as **arguments to the binary**, not as a shell command. The binary then receives unexpected positional arguments and typically exits non-zero.

## Fix

Use `--entrypoint /bin/sh` to unconditionally override any entrypoint:

```bash
docker run --rm --entrypoint /bin/sh image -c "${SMOKE_CMD}"
```

This is consistent with how `smoke-test-entrypoint-cmd` already works (line 143). It is safe for all image types:
- Images with no `ENTRYPOINT`: behavior unchanged
- Images with a shell wrapper `ENTRYPOINT` (e.g. `owncloudci/php`): entrypoint override, shell command still runs correctly
- Images with a binary `ENTRYPOINT` (e.g. `owncloudci/wait-for`): now works correctly

## Reference

Discovered while fixing the smoke test in [owncloud-ci/wait-for#164](https://github.com/owncloud-ci/wait-for/pull/164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)