### PR TITLE
feat: native multi-arch docker build (opt-in reusable workflow)

### DIFF
--- a/.github/workflows/docker-build-native.yml
+++ b/.github/workflows/docker-build-native.yml
@@ -201,6 +201,7 @@ jobs:
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           mkdir -p "${RUNNER_TEMP}/digests"
+          [ -n "${DIGEST}" ] || { echo "::error::push step produced no digest"; exit 1; }
           touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
@@ -246,10 +247,12 @@ jobs:
               [ -n "$tag" ] && TAG_ARGS+=(-t "${DOCKER_REPO_NAME}:${tag}")
             done <<< "${DOCKER_EXTRA_TAGS}"
           fi
+          shopt -s nullglob
           SRC_ARGS=()
           for d in *; do
             SRC_ARGS+=("${DOCKER_REPO_NAME}@sha256:${d}")
           done
+          [ "${#SRC_ARGS[@]}" -gt 0 ] || { echo "::error::no digest files found"; exit 1; }
           docker buildx imagetools create "${TAG_ARGS[@]}" "${SRC_ARGS[@]}"
 
       - name: Inspect manifest

--- a/.github/workflows/docker-build-native.yml
+++ b/.github/workflows/docker-build-native.yml
@@ -105,3 +105,156 @@ jobs:
           build-args: ${{ inputs.docker-build-args }}
           cache-from: ${{ inputs.docker-cache-from != '' && format('{0},scope={1}', inputs.docker-cache-from, matrix.arch) || '' }}
           cache-to: ${{ inputs.docker-cache-to != '' && format('{0},scope={1}', inputs.docker-cache-to, matrix.arch) || '' }}
+
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: localhost/image:temp
+          hide-progress: true
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          skip-files: /usr/bin/gomplate,/usr/bin/wait-for
+          exit-code: 1
+          trivyignores: ${{ inputs.trivy-ignore-files }}
+
+      - name: Smoke test
+        if: ${{ inputs.smoke-test-url != '' }}
+        env:
+          SMOKE_PORT: ${{ inputs.smoke-test-port }}
+          SMOKE_URL: ${{ inputs.smoke-test-url }}
+          SMOKE_ENV: ${{ inputs.smoke-test-env }}
+          SMOKE_ENTRYPOINT_CMD: ${{ inputs.smoke-test-entrypoint-cmd }}
+          SMOKE_VERSION_JQ: ${{ inputs.smoke-test-version-jq }}
+          DOCKER_TAG: ${{ inputs.docker-tag }}
+        run: |
+          ARGS=(--rm -d)
+          [ -n "${SMOKE_PORT}" ] && ARGS+=(-p "${SMOKE_PORT}:${SMOKE_PORT}")
+          if [ -n "${SMOKE_ENV}" ]; then
+            while IFS= read -r line; do
+              [ -n "$line" ] && ARGS+=(--env "${line}")
+            done <<< "${SMOKE_ENV}"
+          fi
+          if [ -n "${SMOKE_ENTRYPOINT_CMD}" ]; then
+            CID=$(docker run "${ARGS[@]}" --entrypoint /bin/sh localhost/image:temp -c "${SMOKE_ENTRYPOINT_CMD}")
+          else
+            CID=$(docker run "${ARGS[@]}" localhost/image:temp)
+          fi
+          [ -z "${CID}" ] && { echo "docker run failed to start"; exit 1; }
+          trap "docker stop ${CID} > /dev/null" EXIT
+          echo "Container started: ${CID}"
+          echo "Polling ${SMOKE_URL} ..."
+          STATUS=""
+          ELAPSED=0
+          for i in $(seq 1 31); do
+            STATUS=$(curl -sk -o /dev/null -w "%{http_code}" "${SMOKE_URL}") || STATUS="000"
+            if [ "${STATUS}" = "200" ]; then
+              echo "Got HTTP 200 after ${ELAPSED}s"
+              break
+            fi
+            sleep 2
+            ELAPSED=$((ELAPSED + 2))
+          done
+          if [ "${STATUS}" != "200" ]; then
+            echo "Timed out after 60s waiting for HTTP 200 (last status: ${STATUS})"
+            docker logs "${CID}"
+            exit 1
+          fi
+          if [ -n "${SMOKE_VERSION_JQ}" ]; then
+            ACTUAL=$(curl -sk "${SMOKE_URL}" | jq -r "${SMOKE_VERSION_JQ}")
+            if [ "${ACTUAL}" != "${DOCKER_TAG}" ]; then
+              echo "Version mismatch: expected '${DOCKER_TAG}', got '${ACTUAL}'"
+              exit 1
+            fi
+            echo "Version verified: ${ACTUAL}"
+          fi
+
+      - name: Smoke test (cmd)
+        if: ${{ inputs.smoke-test-cmd != '' }}
+        env:
+          SMOKE_CMD: ${{ inputs.smoke-test-cmd }}
+        run: |
+          docker run --rm --entrypoint /bin/sh localhost/image:temp -c "${SMOKE_CMD}"
+
+      - name: Login to Docker Hub
+        if: ${{ inputs.push }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ inputs.docker-hub-username }}
+          password: ${{ secrets.docker-hub-password }}
+
+      - name: Push image by digest
+        if: ${{ inputs.push }}
+        id: push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          platforms: linux/${{ matrix.arch }}
+          secrets: ${{ secrets.docker-secrets }}
+          build-args: ${{ inputs.docker-build-args }}
+          cache-from: ${{ inputs.docker-cache-from != '' && format('{0},scope={1}', inputs.docker-cache-from, matrix.arch) || '' }}
+          outputs: type=image,name=${{ inputs.docker-repo-name }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        if: ${{ inputs.push }}
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        if: ${{ inputs.push }}
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: digest-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: build
+    if: ${{ inputs.push }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ inputs.docker-hub-username }}
+          password: ${{ secrets.docker-hub-password }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          DOCKER_REPO_NAME: ${{ inputs.docker-repo-name }}
+          DOCKER_TAG: ${{ inputs.docker-tag }}
+          DOCKER_EXTRA_TAGS: ${{ inputs.docker-extra-tags }}
+        run: |
+          TAG_ARGS=(-t "${DOCKER_REPO_NAME}:${DOCKER_TAG}")
+          if [ -n "${DOCKER_EXTRA_TAGS}" ]; then
+            while IFS= read -r tag; do
+              [ -n "$tag" ] && TAG_ARGS+=(-t "${DOCKER_REPO_NAME}:${tag}")
+            done <<< "${DOCKER_EXTRA_TAGS}"
+          fi
+          SRC_ARGS=()
+          for d in *; do
+            SRC_ARGS+=("${DOCKER_REPO_NAME}@sha256:${d}")
+          done
+          docker buildx imagetools create "${TAG_ARGS[@]}" "${SRC_ARGS[@]}"
+
+      - name: Inspect manifest
+        env:
+          DOCKER_REPO_NAME: ${{ inputs.docker-repo-name }}
+          DOCKER_TAG: ${{ inputs.docker-tag }}
+        run: |
+          docker buildx imagetools inspect "${DOCKER_REPO_NAME}:${DOCKER_TAG}"

--- a/.github/workflows/docker-build-native.yml
+++ b/.github/workflows/docker-build-native.yml
@@ -1,0 +1,107 @@
+on:
+  workflow_call:
+    inputs:
+      docker-repo-name:
+        required: true
+        type: string
+      docker-tag:
+        required: true
+        type: string
+      docker-context:
+        required: true
+        type: string
+      docker-file:
+        required: true
+        type: string
+      docker-hub-username:
+        required: true
+        type: string
+      docker-build-args:
+        required: false
+        type: string
+      push:
+        required: true
+        type: boolean
+      trivy-ignore-files:
+        required: false
+        type: string
+        default: ".trivyignore"
+      docker-extra-tags:
+        required: false
+        type: string
+        default: ""
+      smoke-test-port:
+        required: false
+        type: string
+        default: ""
+        description: "Port number to expose (host and container port will be identical, e.g. '9200')"
+      smoke-test-url:
+        required: false
+        type: string
+        default: ""
+        description: "URL to poll for HTTP 200 after starting the container. When empty, the smoke test step is skipped."
+      smoke-test-env:
+        required: false
+        type: string
+        default: ""
+        description: "Newline-separated list of KEY=VALUE pairs passed as --env to docker run."
+      smoke-test-entrypoint-cmd:
+        required: false
+        type: string
+        default: ""
+        description: "Override entrypoint to /bin/sh -c '<cmd>'. Must end with a long-running process (e.g. via exec) so the container stays alive for polling."
+      smoke-test-version-jq:
+        required: false
+        type: string
+        default: ""
+        description: "jq expression applied to the JSON response from smoke-test-url; result must equal docker-tag."
+      smoke-test-cmd:
+        required: false
+        type: string
+        default: ""
+        description: "Shell command to run inside the container as a one-shot smoke test (for non-server images). Skipped when empty."
+      docker-cache-from:
+        required: false
+        type: string
+        default: ""
+        description: "BuildKit cache-from value passed to docker/build-push-action (e.g. 'type=gha'). NOTE: native workflow appends a per-arch scope automatically."
+      docker-cache-to:
+        required: false
+        type: string
+        default: ""
+        description: "BuildKit cache-to value passed to docker/build-push-action (e.g. 'type=gha,mode=max'). NOTE: native workflow appends a per-arch scope automatically."
+    secrets:
+      docker-hub-password:
+        required: true
+      docker-secrets:
+        required: false
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Build image (load for testing)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ${{ inputs.docker-context }}
+          file: ${{ inputs.docker-file }}
+          load: true
+          platforms: linux/${{ matrix.arch }}
+          tags: localhost/image:temp
+          secrets: ${{ secrets.docker-secrets }}
+          build-args: ${{ inputs.docker-build-args }}
+          cache-from: ${{ inputs.docker-cache-from != '' && format('{0},scope={1}', inputs.docker-cache-from, matrix.arch) || '' }}
+          cache-to: ${{ inputs.docker-cache-to != '' && format('{0},scope={1}', inputs.docker-cache-to, matrix.arch) || '' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,25 @@ jobs:
           - value: "22.04"
             smoke-test-cmd: ". /etc/os-release && [ \"${VERSION_ID}\" = \"22.04\" ]"
 
+  # Self-test the opt-in native multi-arch reusable workflow end-to-end.
+  # Builds the v24.04 base image on native amd64 + arm64 runners and smoke-tests
+  # each arch. push is always false: this only asserts the native workflow works,
+  # it never publishes (the `build` job above owns publishing via docker-build.yml).
+  build-native:
+    name: build-native (24.04)
+    needs: lint
+    uses: ./.github/workflows/docker-build-native.yml
+    with:
+      docker-repo-name: owncloud/${{ github.event.repository.name }}
+      docker-tag: "24.04"
+      docker-context: v24.04
+      docker-file: v24.04/Dockerfile.multiarch
+      docker-hub-username: ${{ vars.DOCKERHUB_USERNAME }}
+      smoke-test-cmd: ". /etc/os-release && [ \"${VERSION_ID}\" = \"24.04\" ]"
+      push: false
+    secrets:
+      docker-hub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+
   update-docker-hub-description:
     needs: build
     if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## What

Adds a new **opt-in** reusable workflow `docker-build-native.yml` that builds each architecture on a **native** runner instead of emulating arm64 under QEMU.

The existing `docker-build.yml` is **left completely untouched** — current consumers (`server`, `base`, `php`, `ocis` release) are unaffected. A repo opts in by changing its `uses:` line to `docker-build-native.yml@master`.

## Why

`docker-build.yml` hardcodes `platforms: linux/amd64,linux/arm64` on an amd64-only `ubuntu-latest` runner, so the arm64 half builds under QEMU emulation. For source-compiled images (e.g. oCIS: `CGO_ENABLED=1 ENABLE_VIPS=true make release`) the emulated half dominates wall-clock time (~60 min observed). It also means the arm64 image is **never actually run/smoke-tested** today.

## How

Identical input/secret surface to `docker-build.yml`, with this topology:

- **`build`** (matrix: `amd64` → `ubuntu-latest`, `arm64` → `ubuntu-24.04-arm`):
  builds + `--load`s the single-arch image, Trivy-scans it, smoke-tests it **on its native runner**, then (when `push`) logs in, re-builds with `push-by-digest` output, and uploads the digest as an artifact. `cache-from/to` get a per-arch `scope=<arch>` so the two legs don't clobber each other's GHA cache.
- **`merge`** (`if: push`): downloads both digests, runs `docker buildx imagetools create` to assemble the multi-arch manifest under all tags, then `imagetools inspect` to verify.

This is Docker's documented multi-arch-via-matrix pattern.

## Notes

- `ubuntu-24.04-arm` is a GitHub-hosted runner, free for public repos.
- Digest export and manifest merge fail loudly (explicit `::error::` + non-zero exit) if a digest is missing, so a partial build can never silently publish a single-arch manifest.
- All actions pinned to full commit SHAs. `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)