### PR TITLE
feat: apt upgrade on rebuild + dated Docker Hub tag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,6 +30,11 @@ on:
         required: false
         type: string
         default: ""
+      build-date-tag:
+        required: false
+        type: boolean
+        default: false
+        description: "When true, additionally publish an immutable <docker-tag>-<YYYYMMDD> tag."
       smoke-test-port:
         required: false
         type: string
@@ -188,12 +193,16 @@ jobs:
           DOCKER_REPO_NAME: ${{ inputs.docker-repo-name }}
           DOCKER_TAG: ${{ inputs.docker-tag }}
           DOCKER_EXTRA_TAGS: ${{ inputs.docker-extra-tags }}
+          BUILD_DATE_TAG: ${{ inputs.build-date-tag }}
         run: |
           TAGS="${DOCKER_REPO_NAME}:${DOCKER_TAG}"
           if [ -n "${DOCKER_EXTRA_TAGS}" ]; then
             while IFS= read -r tag; do
               [ -n "$tag" ] && TAGS="${TAGS}"$'\n'"${DOCKER_REPO_NAME}:${tag}"
             done <<< "${DOCKER_EXTRA_TAGS}"
+          fi
+          if [ "${BUILD_DATE_TAG}" = "true" ]; then
+            TAGS="${TAGS}"$'\n'"${DOCKER_REPO_NAME}:${DOCKER_TAG}-$(date -u +%Y%m%d)"
           fi
           echo "list<<EOF" >> $GITHUB_OUTPUT
           echo "$TAGS" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
       docker-hub-username: ${{ vars.DOCKERHUB_USERNAME }}
       smoke-test-cmd: ${{ matrix.version.smoke-test-cmd }}
       push: ${{ github.ref == 'refs/heads/master' }}
+      build-date-tag: true
     secrets:
       docker-hub-password: ${{ secrets.DOCKERHUB_TOKEN }}
 

--- a/v22.04/Dockerfile.multiarch
+++ b/v22.04/Dockerfile.multiarch
@@ -22,6 +22,7 @@ ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.1.0}"
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 
 RUN apt-get update -y && \
+  apt-get upgrade -y && \
   apt-get install --no-install-recommends -y \
   ca-certificates \
   bash \

--- a/v24.04/Dockerfile.multiarch
+++ b/v24.04/Dockerfile.multiarch
@@ -22,6 +22,7 @@ ENV WAIT_FOR_VERSION="${WAIT_FOR_VERSION:-v2.1.0}"
 ENV RETRY_VERSION="${RETRY_VERSION:-v2.0.0}"
 
 RUN apt-get update -y && \
+  apt-get upgrade -y && \
   apt-get install --no-install-recommends -y \
   ca-certificates \
   bash \


### PR DESCRIPTION
## What

1. **`apt-get upgrade -y` on rebuild** — both `v22.04/Dockerfile.multiarch` and `v24.04/Dockerfile.multiarch` previously ran only `apt-get update` + `install`, so rebuilds stayed pinned to the base image's original package set. Adding `apt-get upgrade -y` pulls in the latest package versions (including security fixes) on every rebuild.

2. **Immutable dated Docker Hub tag** — adds an opt-in `build-date-tag` boolean input to the reusable `docker-build.yml`, enabled from `main.yml`. On each publish, an additional `<docker-tag>-<YYYYMMDD>` (UTC) tag is pushed alongside the existing floating tags.

## Result

Per matrix version, on merge to `master` and the weekly cron rebuild, Docker Hub receives:

- `owncloud/ubuntu:22.04` / `owncloud/ubuntu:24.04` — **unchanged** floating tags
- `owncloud/ubuntu:22.04-<YYYYMMDD>` / `owncloud/ubuntu:24.04-<YYYYMMDD>` — **new** immutable dated tags

This gives traceability: you can tell which dated build a container came from and pin to a specific historical build.

## Notes

- The date tag is version-prefixed so the two matrix builds never collide on the same day.
- `build-date-tag` defaults to `false`, so other consumers of the reusable workflow are unaffected.
- The `build-native` self-test job is untouched (`push: false`, never publishes).
- Tag-logic dry-run verified output: `owncloud/ubuntu:22.04` + `owncloud/ubuntu:22.04-<date>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)