### PR TITLE
fix: scope per-arch digest artifacts by docker-tag

### DIFF
--- a/.github/workflows/docker-build-native.yml
+++ b/.github/workflows/docker-build-native.yml
@@ -208,7 +208,13 @@ jobs:
         if: ${{ inputs.push }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: digest-${{ matrix.arch }}
+          # Scope the artifact name with docker-tag. Artifact names share a single
+          # namespace per workflow run, so when a caller invokes this reusable
+          # workflow multiple times in one run (e.g. a matrix building several
+          # versions), an unqualified "digest-<arch>" collides across invocations.
+          # download-artifact then resolves the name to a single winning artifact,
+          # making every version's manifest list inherit the same per-arch image.
+          name: digest-${{ inputs.docker-tag }}-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -222,7 +228,9 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
-          pattern: digest-*
+          # Scope to this invocation's docker-tag so a caller building several
+          # tags in one run keeps each manifest list to its own per-arch digests.
+          pattern: digest-${{ inputs.docker-tag }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Problem

When a caller invokes this reusable workflow **multiple times in a single GitHub Actions run** (e.g. an `owncloud/ocis` matrix building `8.0.5` and `8.1.0-rc.2` together), the published multi-arch images come out **cross-contaminated**: different versions share the *same* per-arch image digest on Docker Hub.

Observed on Docker Hub — `8.0.5`, `8.0.5-20260629` and `8.1.0-rc.2` all carried the **identical arm64 digest** `sha256:050b23c785…` (even the attestation blob matched), while their amd64 digests differed:

| tag | amd64 | arm64 |
|---|---|---|
| `8.1.0-rc.2` | `645bb4…` | `050b23…` |
| `8.0.5` | `f8b27e…` | `050b23…` ❌ |

## Root cause

The build jobs were **correct** — the run logs show each arm64 job actually executing `make … VERSION=<v>` and producing distinct image configs (`8.0.5`→`1db22c47…`, `rc.2`→`2d512e9f…`).

The corruption happened **downstream, in artifact naming**. Digests were uploaded under an unqualified `digest-<arch>` name. Artifact names share **one namespace per workflow run**, so the two invocations collided — the run exposed two artifacts literally named `digest-arm64`. The `merge` job's `download-artifact` (`pattern: digest-*`, `merge-multiple: true`) then resolved each name to a *single winning artifact ID*, and **both** versions' merge jobs downloaded the very same arm64 artifact — stamping one version's arm64 binary onto every version's manifest list. amd64 escaped only by which duplicate happened to win; it's non-deterministic, not safe.

## Fix

- **Upload:** qualify the artifact name with `docker-tag` → `digest-${{ inputs.docker-tag }}-${{ matrix.arch }}`, so each invocation gets its own namespace.
- **Download:** scope the merge job's `pattern` to `digest-${{ inputs.docker-tag }}-*`, so each manifest list is assembled only from its own per-arch digests.

Single-invocation callers are unaffected.

### Note / follow-up

The download `pattern` is a glob, so if two tags in the same run were literal prefixes of each other (e.g. `8.0.5` and `8.0.5-rc`), `digest-8.0.5-*` would match both. The current oCIS tags (`8.0.5`, `8.1.0-rc.2`, `latest`) don't overlap, so this is safe today; a fully collision-proof variant would sanitize the tag into the name and match exactly. Kept the glob for simplicity and readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)