### PR TITLE
docs: link to org image lifecycle document

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ ownCloud Docker Ubuntu base image based on the [official Ubuntu](https://registr
 - **Supported architectures:**\
   `amd64`, `arm64v8`
 
+- **Build & maintenance:**\
+  [How these images are built, scanned, updated and published](https://github.com/owncloud-docker/.github/blob/master/docs/IMAGE-LIFECYCLE.md)
+
 ## Docker Tags and respective Dockerfile links
 
 - [`24.04`](https://github.com/owncloud-docker/ubuntu/blob/master/v24.04/Dockerfile.multiarch) available as `owncloud/ubuntu:24.04`


### PR DESCRIPTION
Adds a **Build & maintenance** link in the Quick reference block pointing to the org-level [Image Lifecycle](https://github.com/owncloud-docker/.github/blob/master/docs/IMAGE-LIFECYCLE.md) document, which describes how the ownCloud Docker images are built, tagged, scanned, kept up to date and published.

The link is an absolute URL so it also resolves in the Docker Hub description (this README is published there verbatim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)