### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-07-06
+
+* Added
+  * OSPO community health files (agents.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md,
+    SECURITY.md, SUPPORT.md) and README community/OSPO sections as part of the
+    Kiteworks OSPO community health rollout v2
+
 ## 2025-04-15
 
 * Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+## About this repository
+
+This repository builds the official **ownCloud Ubuntu** Docker image
+([`owncloud/ubuntu`](https://hub.docker.com/r/owncloud/ubuntu)) on top of the
+[official Ubuntu](https://hub.docker.com/_/ubuntu) image. It is the foundation
+layer for the rest of the ownCloud Docker image stack. It also **hosts the
+shared reusable GitHub Actions workflows** (`docker-build.yml`,
+`docker-build-native.yml`, `docker-hub-desc.yml`, `lint-editorconfig.yml`,
+`lint-pr-title.yml`) that the other `owncloud-docker` repositories call. See the
+[README](README.md) for build details, supported tags and usage.
+
+## Pull requests
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Rebase on the target
+  branch before submitting a PR; do not create merge commits.
+- **Signed commits**: All commits **must** be PGP/GPG signed. See
+  [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -S -s -m "your commit message"
+  ```
+- **Conventional Commits**: PR titles must follow the
+  [Conventional Commits](https://www.conventionalcommits.org/) format — this is
+  enforced by CI, and the PR title becomes the squash-merge commit message.
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by
+  `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub
+  Marketplace. Pin all actions to their full commit SHA.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/owncloud-docker/ubuntu)](https://github.com/owncloud-docker/ubuntu/graphs/contributors)
 [![Source: GitHub](https://img.shields.io/badge/source-github-blue.svg?logo=github&logoColor=white)](https://github.com/owncloud-docker/ubuntu)
 [![License: MIT](https://img.shields.io/github/license/owncloud-docker/ubuntu)](https://github.com/owncloud-docker/ubuntu/blob/master/LICENSE)
+[![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource)
 
 ownCloud Docker Ubuntu base image based on the [official Ubuntu](https://registry.hub.docker.com/_/ubuntu/) image.
 
@@ -35,6 +36,60 @@ None
 ## Environment variables
 
 None
+
+## Community & Support
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+See [SUPPORT.md](SUPPORT.md) for the full list of support channels.
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow — rebase on the target
+  branch before submitting a PR.
+- **Signed commits**: All commits **must** be PGP/GPG signed and carry a DCO
+  `Signed-off-by` line (`git commit -S -s`).
+- **Conventional Commits**: PR titles must follow the
+  [Conventional Commits](https://www.conventionalcommits.org/) format — enforced
+  by CI.
+- **GitHub Actions Policy**: Workflows may only use actions owned by `owncloud`,
+  created by GitHub (`actions/*`), or verified in the GitHub Marketplace, pinned
+  to a full commit SHA.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** — see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+This repository is licensed under the permissive **MIT License**, which is already
+compatible with the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+that the OSPO is adopting across the ecosystem. No relicensing or copyleft
+dependency audit is required.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: <https://github.com/orgs/owncloud/discussions>
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,101 @@
+# agents.md — ubuntu
+
+## Repository Overview
+
+This repository builds the official **ownCloud Ubuntu** Docker image
+(`owncloud/ubuntu` on Docker Hub) on top of the
+[official Ubuntu](https://hub.docker.com/_/ubuntu) image. It is the base of the
+ownCloud Docker image stack — [`owncloud/php`](https://github.com/owncloud-docker/php)
+builds `FROM` it. It **also hosts the shared reusable GitHub Actions workflows**
+that every other `owncloud-docker` image repository calls. Images are
+multi-architecture and built via GitHub Actions.
+
+- **Classification:** Docker image build (base layer) + shared CI workflows
+- **Activity Status:** Active
+- **License:** MIT
+- **Language:** Dockerfile, Shell, GitHub Actions YAML
+
+## Architecture & Key Paths
+
+- `v22.04/`, `v24.04/` — one directory per Ubuntu release
+  - `<version>/Dockerfile.multiarch` — image definition (`FROM ubuntu:<version>`)
+  - `<version>/overlay/` — files copied into the image root (`ADD overlay /`)
+- `.github/workflows/` — **the shared reusable workflows for the whole org:**
+  - `docker-build.yml` — cross-compiled multi-arch build, smoke test, Trivy scan,
+    publish (called by `base`, `php`, `server`)
+  - `docker-build-native.yml` — native per-arch build variant (called by `ocis`)
+  - `docker-hub-desc.yml` — sync README to the Docker Hub image description
+    (runs `markdown-link-check` on `README.md`)
+  - `lint-editorconfig.yml` — editorconfig-checker lint
+  - `lint-pr-title.yml` — Conventional-Commit PR-title enforcement
+  - `main.yml` — this repo's own CI, which also self-tests the reusable workflows
+- `.github/dependabot.yml` — weekly GitHub Actions dependency updates
+- `.github/settings.yml` — repository settings management
+- `.renovaterc.json` — Renovate preset for Docker digest updates (Ubuntu major/
+  minor bumps disabled)
+- `.editorconfig` — formatting rules (2-space indent, LF, trailing newline)
+- `.trivyignore` — accepted-CVE exclusions for the Trivy scan
+- `CHANGELOG.md` — flat, date-based changelog at repo root
+- `LICENSE` — MIT
+
+## Build & CI
+
+There is no local application build. `main.yml` builds the `owncloud/ubuntu`
+image via its own reusable workflows and additionally self-tests the native
+multi-arch workflow (`build-native`, which never publishes):
+
+- Matrix builds `22.04` and `24.04`, each via `v<version>/Dockerfile.multiarch`.
+- Smoke test asserts `/etc/os-release`'s `VERSION_ID` matches the tag.
+- Trivy vulnerability scan (`.trivyignore`).
+- On `master`: push to Docker Hub and sync the README as the image description.
+
+**All GitHub Actions inside the reusable workflows are pinned to full commit
+SHAs** (e.g. `actions/checkout@<SHA> # v7.0.0`). When updating an action, keep
+the `# vX.Y.Z` comment in sync with the pinned SHA.
+
+To build locally:
+
+```bash
+docker build -f v24.04/Dockerfile.multiarch v24.04
+```
+
+## Development Conventions
+
+- Date-based `CHANGELOG.md` at repo root — **not** a `changelog/unreleased/`
+  directory. Prepend a new `## YYYY-MM-DD` section for notable changes.
+- Conventional-Commit PR titles, enforced by `lint-pr-title.yml`.
+- `.editorconfig` governs formatting.
+- GitHub Actions are pinned to full commit SHAs.
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`),
+  verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`.
+- Never introduce actions from unverified third parties.
+- Because this repo hosts the shared reusable workflows, changes here affect
+  every downstream image repository — review action bumps carefully.
+
+### Dependency Management
+- Dependabot is configured for GitHub Actions updates; Renovate handles Docker
+  base-image digest updates.
+- Review and merge dependency PRs as part of regular maintenance.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: PR titles must follow
+  [Conventional Commits](https://www.conventionalcommits.org/); the PR title
+  becomes the squash-merge commit message and is enforced by CI.
+
+## Context for AI Agents
+
+- This is a small Docker-image packaging repo that **also owns the org's shared
+  CI workflows** — treat `.github/workflows/*.yml` as a public interface.
+- The two `v*/` directories are near-identical; changes usually apply to both.
+- The README is published verbatim as the Docker Hub image description — keep it
+  accurate and self-contained.
+- License is **MIT** (permissive, already compatible with Apache-2.0); no
+  copyleft dependency audit is required for relicensing.


### PR DESCRIPTION
Incorporate the Kiteworks OSPO community health rollout v2 (adapted from owncloud-docker/server#637) into the `owncloud/ubuntu` image repository. This repo also hosts the shared reusable GitHub Actions workflows for the org.

## Changes

- **README.md**: append Community & Support, Contributing, Security and About the ownCloud OSPO sections plus an OSPO badge (additive — existing Docker reference kept since it is synced to Docker Hub)
- **agents.md**: new AI-agent context file describing the Docker build, the shared reusable workflows, CI and OSPO policy
- **CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md, SUPPORT.md**: new community health files
- **CHANGELOG.md**: dated entry following the existing convention

License is **MIT** (permissive, already Apache-2.0 compatible) — no relicensing or copyleft dependency audit required. No workflow changes — the reusable workflows' actions are already SHA-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)